### PR TITLE
allow providing custom key size

### DIFF
--- a/free_tls_certificates/client.py
+++ b/free_tls_certificates/client.py
@@ -43,11 +43,12 @@ class HTTPValidation(DomainValidationMethod):
 
 def issue_certificate(
         domains, account_cache_directory,
-        agree_to_tos_url=None, 
+        agree_to_tos_url=None,
         validation_method=HTTPValidation(),
         certificate_file=None,
         certificate_chain_file=APPEND_CHAIN,
-        private_key=None, private_key_file=None, csr=None,
+        private_key=None, private_key_file=None,
+        private_key_size=2048, csr=None,
         self_signed=None,
         acme_server=LETSENCRYPT_SERVER,
         logger=lambda s : None,
@@ -66,7 +67,7 @@ def issue_certificate(
     # Domains are now validated. Generate a private key, CSR, and certificate.
 
     # Load or generate a private key.
-    (private_key, private_key_pem) = generate_private_key(private_key, private_key_file, logger)
+    (private_key, private_key_pem) = generate_private_key(private_key, private_key_file, private_key_size, logger)
 
     if not self_signed:
         # Load or generate a certificate signing request.
@@ -140,7 +141,9 @@ def validate_domain_ownership(
     return (client, challgs)
 
 
-def generate_private_key(private_key, private_key_file, logger):
+def generate_private_key(
+        private_key, private_key_file, private_key_size, logger
+        ):
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
@@ -155,7 +158,7 @@ def generate_private_key(private_key, private_key_file, logger):
     if private_key is None:
         # Generate a new private key if not given to us.
         logger("Generating a new private key.")
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=private_key_size, backend=default_backend())
         private_key_pem = private_key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.TraditionalOpenSSL, encryption_algorithm=serialization.NoEncryption())
 
     elif isinstance(private_key, bytes):

--- a/free_tls_certificates/driver.py
+++ b/free_tls_certificates/driver.py
@@ -61,6 +61,7 @@ def parse_command_line():
     acme_server = LETSENCRYPT_SERVER
     self_signed = False
     append_well_known_acme_challenge = True
+    private_key_size = 2048
     while True:
         if args[0] == "--server":
             args.pop(0)
@@ -77,13 +78,20 @@ def parse_command_line():
             args.pop(0)
             append_well_known_acme_challenge = False
             continue
+        if args[0] == "--private-key-size":
+            args.pop(0)
+            private_key_size = args.pop(0)
+            if private_key_size not in ["1024", "2048", "4096"]:
+                raise Exception("Key size must be 1024, 2048 or 4096.")
+            private_key_size = int(private_key_size)
+            continue
         break
 
     # Get the ACME arguments.
     if not self_signed:
         if len(args) < 2:
             raise Exception("Not enough command-line arguments.")
-        
+
         acme_account_path = args.pop(-1)
         static_path = args.pop(-1)
 
@@ -115,6 +123,7 @@ def parse_command_line():
         "acme_server": acme_server,
         "domains": domains,
         "private_key_fn": private_key_fn,
+        "private_key_size": private_key_size,
         "certificate_fn": certificate_fn,
         "static_path": static_path,
         "acme_account_path": acme_account_path,
@@ -193,6 +202,7 @@ def provision_certificate(opts):
                 opts["acme_account_path"],
                 certificate_file=opts["certificate_fn"],
                 private_key_file=opts["private_key_fn"],
+                private_key_size=opts["private_key_size"],
                 agree_to_tos_url=agree_to_tos_url,
                 acme_server=opts["acme_server"],
                 self_signed=opts["self_signed"],
@@ -225,7 +235,7 @@ provision your TLS certificate. If you don't agree, this program stops.
 Do you agree to the agreement? Type Y or N and press <ENTER>: """
                  % e.url)
             sys.stdout.flush()
-            
+
             if sys.stdin.readline().strip().upper() != "Y":
                 print("\nYou didn't agree. Quitting.")
                 sys.exit(1)
@@ -318,4 +328,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Adds a `--private-key-size` command-line argument and `private_key_size` param to `issue_certificate()`, which is passed directly to `rsa.generate_private_key()`