### PR TITLE
Use josepy instead of acme.jose

### DIFF
--- a/free_tls_certificates/client.py
+++ b/free_tls_certificates/client.py
@@ -11,6 +11,8 @@ import acme.client
 import acme.messages
 import acme.challenges
 
+import josepy as jose
+
 import OpenSSL.crypto
 
 import idna
@@ -191,7 +193,7 @@ def parse_or_generate_csr(domains, csr, private_key, logger):
 
 def request_certificate_issuance(client, challgs, csr, logger):
     # Convert the OpenSSL.crypto.X509Req to a ComparableX509 expected by request_issuance.
-    csr = acme.jose.util.ComparableX509(csr)
+    csr = jose.util.ComparableX509(csr)
 
     # Request a certificate using the CSR and some number of domain validation challenges.
     logger("Requesting a certificate.")
@@ -334,7 +336,6 @@ def create_client(account_key_file, registration_file, log, agree_to_tos_url=Non
 # loading it from keyfile if the file exists, otherwise generating
 # a new key and writing it to that file.
 def load_or_generate_private_key(keyfile, log):
-    from acme import jose
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric import rsa
     from cryptography.hazmat.primitives import serialization

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography
 acme>=0.2.0
 idna
+josepy


### PR DESCRIPTION
As of this [PR](https://github.com/certbot/certbot/pull/5203), letsencrypt is using josepy. We should do so, since this module is not usable in mailinabox project.